### PR TITLE
Log the matched name when resolving

### DIFF
--- a/service-locator-dns/src/main/scala/com/lightbend/dns/locator/ServiceLocator.scala
+++ b/service-locator-dns/src/main/scala/com/lightbend/dns/locator/ServiceLocator.scala
@@ -140,8 +140,8 @@ class ServiceLocator extends Actor with ActorSettings with ActorLogging {
   }
 
   private def resolveSrv(name: String, resolveOne: Boolean): Unit = {
-    log.debug("Resolving: {}", name)
     val matchedName = matchName(name, settings.nameTranslators)
+    log.debug("Resolving: {} -> {}", name, matchedName)
     matchedName.foreach { mn =>
       val replyTo = sender()
       import context.dispatcher


### PR DESCRIPTION
Ensure the result of `matchName` is also logged to debug so that the user can know that his or her name translator is working properly.