### PR TITLE
Implement support for translating srv records after they are looked up

### DIFF
--- a/service-locator-dns/src/main/resources/reference.conf
+++ b/service-locator-dns/src/main/resources/reference.conf
@@ -38,6 +38,22 @@ service-locator-dns {
   ]
   name-translators = ${?SERVICE_LOCATOR_DNS_NAME_TRANSLATORS}
 
+  # A list of translators - their order is significant. Translates the SRV lookup name for downstream processing by
+  # the library. The name will initially be looked up (after being passed through name-translators), and then the
+  # result will be mapped according to this translation table.
+  #
+  # For example, this entry will rewrite any queries starting with _api._tcp and ensuring they become _api._http
+  #
+  # "^_api[.]_tcp[.](.+)$" = "_api.http.$1",
+  #
+  # By default, we don't transluate i.e. we let it all pass through.
+  srv-translators = [
+    {
+      "^.*$" = "$0"
+    }
+  ]
+  srv-translators = ${?SERVICE_LOCATOR_DNS_SRV_TRANSLATORS}
+
   # The amount of time to wait for a DNS resolution to occur for the first and second lookups of a given
   # name.
   resolve-timeout1 = 1 second

--- a/service-locator-dns/src/main/scala/com/lightbend/dns/locator/Settings.scala
+++ b/service-locator-dns/src/main/scala/com/lightbend/dns/locator/Settings.scala
@@ -20,10 +20,17 @@ object Settings extends ExtensionKey[Settings]
  * Settings for the service locator.
  */
 class Settings(system: ExtendedActorSystem) extends Extension {
-
   val nameTranslators: Seq[(Regex, String)] =
     serviceLocatorDns
       .getObjectList("name-translators")
+      .toList
+      .flatMap(_.toMap.map {
+        case (k, v) => k.r -> v.unwrapped().toString
+      })
+
+  val srvTranslators: Seq[(Regex, String)] =
+    serviceLocatorDns
+      .getObjectList("srv-translators")
       .toList
       .flatMap(_.toMap.map {
         case (k, v) => k.r -> v.unwrapped().toString


### PR DESCRIPTION
This PR adds the ability to translate an SRV name after it is queries for but before it is parsed for protocol.

This allows you to e.g. query Kubernetes for TCP services and have that be rewritten to HTTP.

Fixes #7 