### PR TITLE
Ensure the reply includes the hostname as well

### DIFF
--- a/lagom-service-locator-dns/src/test/scala/com/lightbend/lagom/dns/DNSServiceLocatorSpec.scala
+++ b/lagom-service-locator-dns/src/test/scala/com/lightbend/lagom/dns/DNSServiceLocatorSpec.scala
@@ -42,7 +42,7 @@ class DNSServiceLocatorSpec extends WordSpec with Matchers with BeforeAndAfterAl
       val service = serviceLocator.locate("some-service", Descriptor.Call.NONE).toScala.map(_.asScala)
 
       dnsServiceLocator.expectMsg(ServiceLocatorService.GetAddress("some-service"))
-      dnsServiceLocator.sender() ! ServiceLocatorService.Addresses(List(ServiceLocatorService.ServiceAddress("http", "127.0.0.1", 9000)))
+      dnsServiceLocator.sender() ! ServiceLocatorService.Addresses(List(ServiceLocatorService.ServiceAddress("http", "localhost", "127.0.0.1", 9000)))
 
       service.futureValue shouldBe Some(new URI("http://127.0.0.1:9000"))
     }

--- a/service-locator-dns/src/main/scala/com/lightbend/dns/locator/ServiceLocator.scala
+++ b/service-locator-dns/src/main/scala/com/lightbend/dns/locator/ServiceLocator.scala
@@ -61,7 +61,7 @@ object ServiceLocator {
   /**
    * Used within replies.
    */
-  final case class ServiceAddress(protocol: String, host: String, port: Int)
+  final case class ServiceAddress(protocol: String, hostname: String, host: String, port: Int)
 
   private[locator] final case class RequestContext(replyTo: ActorRef, resolveOne: Boolean, srv: Seq[SRVRecord])
 
@@ -133,8 +133,8 @@ class ServiceLocator extends Actor with ActorSettings with ActorLogging {
             case (resolved, srv) =>
               val protocol = protocolFromName(srv.name)
               val port = srv.port
-              resolved.ipv4.map(host => ServiceAddress(protocol, host.getHostAddress, port)) ++
-                resolved.ipv6.map(host => ServiceAddress(protocol, host.getHostAddress, port))
+              resolved.ipv4.map(host => ServiceAddress(protocol, srv.target, host.getHostAddress, port)) ++
+                resolved.ipv6.map(host => ServiceAddress(protocol, srv.target, host.getHostAddress, port))
           }
       rc.replyTo ! Addresses(addresses)
   }

--- a/service-locator-dns/src/test/scala/com/lightbend/dns/locator/ServiceLocatorSpec.scala
+++ b/service-locator-dns/src/test/scala/com/lightbend/dns/locator/ServiceLocatorSpec.scala
@@ -66,8 +66,8 @@ class ServiceLocatorSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       requestor.expectMsg(
         Addresses(
           Seq(
-            ServiceAddress("tcp", "1.1.1.1", 1000),
-            ServiceAddress("tcp", "1.1.1.2", 1001)
+            ServiceAddress("tcp", "some-service-host1.marathon.mesos", "1.1.1.1", 1000),
+            ServiceAddress("tcp", "some-service-host2.marathon.mesos", "1.1.1.2", 1001)
           )
         )
       )
@@ -94,7 +94,7 @@ class ServiceLocatorSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       dnsProbe.sender() ! Dns.Resolved(expectedHostname, List(InetAddress.getByName(expectedHost)))
       dnsProbe.expectNoMsg(500.millis)
 
-      requestor.expectMsg(Addresses(Seq(ServiceAddress("tcp", expectedHost, expectedPort))))
+      requestor.expectMsg(Addresses(Seq(ServiceAddress("tcp", expectedHostname, expectedHost, expectedPort))))
     }
 
     "Fail to resolve a service due to no srv resolution" in {
@@ -185,7 +185,7 @@ class ServiceLocatorSpec extends WordSpec with Matchers with BeforeAndAfterAll {
       dnsProbe.reply(Dns.Resolved("some-service-host.marathon.mesos", List(InetAddress.getByName("127.0.0.1"))))
       dnsProbe.expectNoMsg(500.millis)
 
-      requestor.expectMsg(Addresses(Seq(ServiceAddress("http", "127.0.0.1", 1000))))
+      requestor.expectMsg(Addresses(Seq(ServiceAddress("http", "some-service-host.marathon.mesos", "127.0.0.1", 1000))))
     }
   }
 


### PR DESCRIPTION
This PR adjusts the DNS service locator to reply with the hostname (i.e. the target field in the DNS SRV record) as well. This can then be included in client connections for TLS hostname verification.