### PR TITLE
configurable static service mappings

### DIFF
--- a/service-locator-dns/src/main/resources/reference.conf
+++ b/service-locator-dns/src/main/resources/reference.conf
@@ -65,7 +65,11 @@ service-locator-dns {
   srv-translators = ${?SERVICE_LOCATOR_DNS_SRV_TRANSLATORS}
 
   # A list of external service mappings. These mappings will be used by service locator to resolve without dns 
-  # configuration, helpful for non lagom or external services (implemented for kubernetes in mind).This can be easily overridden by providing a 
+  # configuration, helpful for non lagom or external services (implemented for kubernetes in mind). eg: 
+  #
+  # external-services = [{"service-name":"https://service-host:port"}]
+  #
+  #This can be easily overridden by providing a 
   # SERVICE_LOCATOR_DNS_EXTERNAL_SERVICES environment variable.
   external-services = []
   external-services = ${?SERVICE_LOCATOR_DNS_EXTERNAL_SERVICES}

--- a/service-locator-dns/src/main/resources/reference.conf
+++ b/service-locator-dns/src/main/resources/reference.conf
@@ -64,6 +64,12 @@ service-locator-dns {
   ]
   srv-translators = ${?SERVICE_LOCATOR_DNS_SRV_TRANSLATORS}
 
+  # A list of external service mappings. These mappings will be used by service locator to resolve without dns 
+  # configuration, helpful for non lagom or external services (implemented for kubernetes in mind).This can be easily overridden by providing a 
+  # SERVICE_LOCATOR_DNS_EXTERNAL_SERVICES environment variable.
+  external-services = []
+  external-services = ${?SERVICE_LOCATOR_DNS_EXTERNAL_SERVICES}
+
   # The amount of time to wait for a DNS resolution to occur for the first and second lookups of a given
   # name.
   resolve-timeout1 = 1 second

--- a/service-locator-dns/src/main/scala/com/lightbend/dns/locator/Settings.scala
+++ b/service-locator-dns/src/main/scala/com/lightbend/dns/locator/Settings.scala
@@ -46,6 +46,14 @@ class Settings(system: ExtendedActorSystem) extends Extension {
         case (k, v) => k.r -> v.unwrapped().toString
       })
 
+  val externalServices: Map[String, String] =
+    serviceLocatorDns
+      .getObjectList("external-services")
+      .toList
+      .flatMap(x => x.toMap.map {
+        case (k, v) => k -> v.unwrapped().toString
+      }).toMap
+
   val resolveTimeout1: FiniteDuration =
     duration(serviceLocatorDns, "resolve-timeout1")
 


### PR DESCRIPTION
this provides extra static service mapping in addition to DNS resolutions. 
This is helpful for external services which can be configurable.
This avoids name translators and srv translators for existing/external services by picking from configuration instead

For urgency for company requirement, I've not followed any best practices. 

I would like to contribute/discuss.